### PR TITLE
Updated scram to version 2.0-beta3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,14 @@
         <skip.unzip-jdk-src>false</skip.unzip-jdk-src>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>com.ongres.scram</groupId>
+            <artifactId>client</artifactId>
+            <version>2.0-beta3</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>
@@ -62,6 +70,58 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+            <version>3.1.0</version>
+            <configuration>
+              <minimizeJar>true</minimizeJar>
+              <filters>
+                <filter>
+                  <artifact>com.ongres.scram:client</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+                <filter>
+                  <artifact>com.github.waffle:waffle-jna</artifact>
+                  <excludes>
+                    <exclude>**</exclude>
+                  </excludes>
+                </filter>
+                <filter>
+                  <artifact>org.slf4j:jcl-over-slf4j</artifact>
+                  <excludes>
+                    <exclude>**</exclude>
+                  </excludes>
+                </filter>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>com/sun/jna/**</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+                <configuration>
+                  <relocations>
+                    <relocation>
+                      <pattern>com.ongres</pattern>
+                      <shadedPattern>org.postgresql.shaded.com.ongres</shadedPattern>
+                    </relocation>
+                  </relocations>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
     </build>
 
     <!-- If inherited from parent pom, maven tries to add artifactId to URLs -->


### PR DESCRIPTION
Updated scram library version 2.0-beta3 with support for Java 7+ and standard SaslPrep implementation.

See also [PR on pgjdbc repository related to this one](https://github.com/pgjdbc/pgjdbc/pull/1525)